### PR TITLE
Fixes #101

### DIFF
--- a/src/main/kotlin/com/viartemev/thewhiterabbit/channel/Channel.kt
+++ b/src/main/kotlin/com/viartemev/thewhiterabbit/channel/Channel.kt
@@ -3,17 +3,17 @@ package com.viartemev.thewhiterabbit.channel
 import com.rabbitmq.client.Channel
 import com.rabbitmq.client.Connection
 import com.viartemev.thewhiterabbit.consumer.ConfirmConsumer
-import kotlin.concurrent.getOrSet
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.concurrent.thread
 
-private val localChannel = ThreadLocal<Channel>()
-
+private val localChannels = ConcurrentHashMap<Thread, UncloseableChannel>()
+private val c = Cleaner
 fun Channel.consumer(queue: String, prefetchSize: Int) = ConfirmConsumer(this, queue, prefetchSize)
 
-suspend fun Connection.channel(block: suspend Channel.() -> Unit): Channel {
-    val channel = localChannel.getOrSet { this.createChannel() }
-    channel.use { block(it) }
-    return channel
-}
+suspend fun Connection.channel(block: suspend Channel.() -> Unit): Channel =
+    localChannels
+        .computeIfAbsent(Thread.currentThread()) { UncloseableChannel(this.createChannel()) }
+        .also { block(it) }
 
 suspend fun Channel.consume(queue: String, prefetchSize: Int = 0, block: suspend ConfirmConsumer.() -> Unit) {
     val consumer = this.consumer(queue, prefetchSize)
@@ -21,5 +21,21 @@ suspend fun Channel.consume(queue: String, prefetchSize: Int = 0, block: suspend
         block(consumer)
     } finally {
         consumer.cancel()
+    }
+}
+
+private class UncloseableChannel(private val channel: Channel) : Channel by channel {
+    override fun close() {}
+
+    override fun close(closeCode: Int, closeMessage: String?) {}
+
+    internal fun close0() = channel.close()
+}
+
+private object Cleaner {
+    init {
+        Runtime.getRuntime().addShutdownHook(thread {
+            localChannels.values.forEach { it.close0() }
+        })
     }
 }

--- a/src/main/kotlin/com/viartemev/thewhiterabbit/channel/Channel.kt
+++ b/src/main/kotlin/com/viartemev/thewhiterabbit/channel/Channel.kt
@@ -3,11 +3,14 @@ package com.viartemev.thewhiterabbit.channel
 import com.rabbitmq.client.Channel
 import com.rabbitmq.client.Connection
 import com.viartemev.thewhiterabbit.consumer.ConfirmConsumer
+import kotlin.concurrent.getOrSet
+
+private val localChannel = ThreadLocal<Channel>()
 
 fun Channel.consumer(queue: String, prefetchSize: Int) = ConfirmConsumer(this, queue, prefetchSize)
 
 suspend fun Connection.channel(block: suspend Channel.() -> Unit): Channel {
-    val channel = this.createChannel()
+    val channel = localChannel.getOrSet { this.createChannel() }
     channel.use { block(it) }
     return channel
 }

--- a/src/main/kotlin/com/viartemev/thewhiterabbit/channel/ConfirmChannel.kt
+++ b/src/main/kotlin/com/viartemev/thewhiterabbit/channel/ConfirmChannel.kt
@@ -3,9 +3,10 @@ package com.viartemev.thewhiterabbit.channel
 import com.rabbitmq.client.Channel
 import com.rabbitmq.client.Connection
 import com.viartemev.thewhiterabbit.publisher.ConfirmPublisher
-import kotlin.concurrent.getOrSet
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.concurrent.thread
 
-class ConfirmChannel internal constructor(private val channel: Channel) : Channel by channel {
+open class ConfirmChannel internal constructor(private val channel: Channel) : Channel by channel {
     init {
         channel.confirmSelect()
     }
@@ -13,7 +14,8 @@ class ConfirmChannel internal constructor(private val channel: Channel) : Channe
     fun publisher() = ConfirmPublisher(this)
 }
 
-private val localChannel = ThreadLocal<ConfirmChannel>()
+private val localChannels = ConcurrentHashMap<Thread, UncloseableConfirmChannel>()
+private val c = ConfirmCleaner
 
 /**
  * Create a channel with enabled publisher acknowledgements on it.
@@ -21,13 +23,28 @@ private val localChannel = ThreadLocal<ConfirmChannel>()
  */
 fun Connection.createConfirmChannel(): ConfirmChannel = ConfirmChannel(this.createChannel())
 
-suspend fun Connection.confirmChannel(block: suspend ConfirmChannel.() -> Unit): ConfirmChannel {
-    val confirmChannel = localChannel.getOrSet { this.createConfirmChannel() }
-    confirmChannel.use { block(it) }
-    return confirmChannel
-}
+suspend fun Connection.confirmChannel(block: suspend ConfirmChannel.() -> Unit): ConfirmChannel =
+    localChannels
+        .computeIfAbsent(Thread.currentThread()) { UncloseableConfirmChannel(this.createConfirmChannel()) }
+        .also { block(it) }
 
 suspend fun ConfirmChannel.publish(block: suspend ConfirmPublisher.() -> Unit) {
     val publisher = this.publisher()
     block(publisher)
+}
+
+private class UncloseableConfirmChannel(private val channel: ConfirmChannel) : ConfirmChannel(channel) {
+    override fun close() {}
+
+    override fun close(closeCode: Int, closeMessage: String?) {}
+
+    internal fun close0() = channel.close()
+}
+
+private object ConfirmCleaner {
+    init {
+        Runtime.getRuntime().addShutdownHook(thread {
+            localChannels.values.forEach { it.close0() }
+        })
+    }
 }

--- a/src/main/kotlin/com/viartemev/thewhiterabbit/channel/ConfirmChannel.kt
+++ b/src/main/kotlin/com/viartemev/thewhiterabbit/channel/ConfirmChannel.kt
@@ -38,13 +38,16 @@ private class UncloseableConfirmChannel(private val channel: ConfirmChannel) : C
 
     override fun close(closeCode: Int, closeMessage: String?) {}
 
-    internal fun close0() = channel.close()
+    internal fun close0() {
+        if (channel.isOpen) channel.close()
+    }
 }
 
 private object ConfirmCleaner {
     init {
         Runtime.getRuntime().addShutdownHook(thread {
             localChannels.values.forEach { it.close0() }
+            localChannels.clear()
         })
     }
 }


### PR DESCRIPTION
This commit adds very simple ThreadLocal cache for channels. It
assumes that any thread can have 2 channels — basic and confirm ones.
Also it should make channel obtaining faster because it will be get from
cache, no any resource allocation will happen and so on.